### PR TITLE
Fix enum import

### DIFF
--- a/src/routes/(app)/ongeveer/products/create/+page.server.ts
+++ b/src/routes/(app)/ongeveer/products/create/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad, Actions } from './$types';
 import db from '$lib/server/db';
-import { ProductType } from '@prisma/client';
+import type { ProductType } from '@prisma/client';
 import { fail } from '@sveltejs/kit';
 import { authorization } from '$lib/ongeveer/utils';
 import { superValidate } from 'sveltekit-superforms/server';
@@ -26,9 +26,11 @@ export const load = (async ({ url }) => {
 	const categories = await db.productCategory.findMany();
 	const form = await superValidate(data, productSchema);
 
+	const productTypes: ProductType[] = ['FOOD', 'ALCOHOL', 'OTHER'];
+
 	return {
 		categories,
-		productTypes: Object.values(ProductType),
+		productTypes,
 		form
 	};
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Fixes #324 

Het probleem is dat je een enum gegenereerd door prisma niet kan importen. Zie https://github.com/prisma/prisma/issues/12504

Mensen hebben allemaal hacky work arounds gevonden maar het leek me beter om dat niet te doen. Dus hier is de fix. Nadeel is dat als je ooit een product type toevoegt hij niet automatisch meer in de UI komt. Als je een product type verwijderd zal TS wel gaan klagen dus dat is top. 